### PR TITLE
Feature/schematic for modules

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,10 +1,10 @@
 module.exports = {
-    // this will check Typescript files
-    '**/*.(ts)': () => 'tsc --noEmit',
+	// this will check Typescript files
+	'**/*.(ts),!**/schematics/module/template/**/*': () => 'tsc --noEmit',
 
-    // This will lint and format TypeScript and                                             //JavaScript files
-    '**/*.(ts|js)': filenames => [`eslint --fix ${filenames.join(' ')}`, `prettier --write ${filenames.join(' ')}`],
+	// This will lint and format TypeScript and JavaScript files
+	'**/*.(ts|js),!**/schematics/module/template/**/*': filenames => [`eslint --fix ${filenames.join(' ')}`, `prettier --write ${filenames.join(' ')}`],
 
-    // this will Format MarkDown and JSON
-    '**/*.(md|json)': filenames => `prettier --write ${filenames.join(' ')}`,
+	// this will Format MarkDown and JSON
+	'**/*.(md|json)': filenames => `prettier --write ${filenames.join(' ')}`,
 };

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,4 +1,4 @@
 {
-  "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+    "collection": "./schematics/collection.json",
+    "sourceRoot": "src"
 }

--- a/schematics/collection.json
+++ b/schematics/collection.json
@@ -1,0 +1,122 @@
+{
+    "$schema": "../node_modules/@angular-devkit/schematics/collection-schema.json",
+    "schematics": {
+        "application": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/application/application.factory#main",
+            "description": "Create a Nest application.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/application/schema.json"
+        },
+        "angular-app": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/client-app/angular/angular.factory#main",
+            "description": "Create a new Angular application.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/client-app/angular/schema.json"
+        },
+        "class": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/class/class.factory#main",
+            "description": "Create a new class.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/class/schema.json",
+            "aliases": ["cl"]
+        },
+        "controller": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/controller/controller.factory#main",
+            "description": "Create a Nest controller.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/controller/schema.json",
+            "aliases": ["co"]
+        },
+        "decorator": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/decorator/decorator.factory#main",
+            "description": "Create a Nest decorator.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/decorator/schema.json",
+            "aliases": ["d"]
+        },
+        "filter": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/filter/filter.factory#main",
+            "description": "Create a Nest filter.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/filter/schema.json",
+            "aliases": ["f"]
+        },
+        "gateway": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/gateway/gateway.factory#main",
+            "description": "Create a Nest gateway.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/gateway/schema.json",
+            "aliases": ["ga"]
+        },
+        "guard": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/guard/guard.factory#main",
+            "description": "Create a Nest guard.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/guard/schema.json",
+            "aliases": ["gu"]
+        },
+        "interceptor": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/interceptor/interceptor.factory#main",
+            "description": "Create a Nest interceptor.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/interceptor/schema.json",
+            "aliases": ["itc"]
+        },
+        "interface": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/interface/interface.factory#main",
+            "description": "Create a Nest interface.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/interface/schema.json",
+            "aliases": ["itf"]
+        },
+        "middleware": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/middleware/middleware.factory#main",
+            "description": "Create a Nest middleware.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/middleware/schema.json",
+            "aliases": ["mi"]
+        },
+        "module": {
+            "factory": "./commands/module/module.factory#main",
+            "description": "Create a Nest module.",
+            "schema": "./commands/module/schema.json",
+            "aliases": ["mo"]
+        },
+        "pipe": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/pipe/pipe.factory#main",
+            "description": "Create a Nest pipe.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/pipe/schema.json",
+            "aliases": ["pi"]
+        },
+        "provider": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/provider/provider.factory#main",
+            "description": "Create a Nest provider.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/provider/schema.json",
+            "aliases": ["pr"]
+        },
+        "service": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/service/service.factory#main",
+            "description": "Create a Nest service.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/service/schema.json",
+            "aliases": ["s"]
+        },
+        "resolver": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/resolver/resolver.factory#main",
+            "description": "Create a Nest resolver.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/resolver/schema.json",
+            "aliases": ["r"]
+        },
+        "configuration": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/configuration/configuration.factory#main",
+            "description": "Create a Nest CLI configuration.",
+            "aliases": ["config"]
+        },
+        "library": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/library/library.factory#main",
+            "description": "Create a Nest library (mono-repo).",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/library/schema.json",
+            "aliases": ["lib"]
+        },
+        "sub-app": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/sub-app/sub-app.factory#main",
+            "description": "Create a Nest application (mono-repo).",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/sub-app/schema.json",
+            "aliases": ["app"]
+        },
+        "resource": {
+            "factory": "../node_modules/@nestjs/schematics/dist/lib/resource/resource.factory#main",
+            "description": "Create a Nest resource.",
+            "schema": "../node_modules/@nestjs/schematics/dist/lib/resource/schema.json",
+            "aliases": ["res"]
+        }
+    }
+}

--- a/schematics/commands/module/module.factory.d.ts
+++ b/schematics/commands/module/module.factory.d.ts
@@ -1,0 +1,3 @@
+import { Rule } from '@angular-devkit/schematics';
+import { ModuleOptions } from './module.schema';
+export declare function main(options: ModuleOptions): Rule;

--- a/schematics/commands/module/module.factory.js
+++ b/schematics/commands/module/module.factory.js
@@ -1,0 +1,59 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.main = void 0;
+const core_1 = require('@angular-devkit/core');
+const schematics_1 = require('@angular-devkit/schematics');
+const formatting_1 = require('@nestjs/schematics/dist/utils/formatting');
+const module_declarator_1 = require('../../utils/module.declarator');
+const module_finder_1 = require('@nestjs/schematics/dist/utils/module.finder');
+const name_parser_1 = require('@nestjs/schematics/dist/utils/name.parser');
+const source_root_helpers_1 = require('@nestjs/schematics/dist/utils/source-root.helpers');
+function main(options) {
+    options.path = `modules`;
+    options = transform(options);
+    return (tree, context) => {
+        return (0, schematics_1.branchAndMerge)(
+            (0, schematics_1.chain)([
+                (0, source_root_helpers_1.mergeSourceRoot)(options),
+                addDeclarationToModule(options),
+                (0, schematics_1.mergeWith)(generate(options)),
+            ]),
+        )(tree, context);
+    };
+}
+exports.main = main;
+function transform(source) {
+    const target = Object.assign({}, source);
+    target.metadata = 'imports';
+    target.type = 'module';
+    const location = new name_parser_1.NameParser().parse(target);
+    target.name = (0, formatting_1.normalizeToKebabOrSnakeCase)(location.name);
+    target.path = (0, formatting_1.normalizeToKebabOrSnakeCase)(location.path);
+    target.language = 'ts';
+    return target;
+}
+function generate(options) {
+    return context =>
+        (0, schematics_1.apply)((0, schematics_1.url)('./template'), [
+            (0, schematics_1.template)(Object.assign(Object.assign({}, core_1.strings), options)),
+            (0, schematics_1.move)(options.path),
+        ])(context);
+}
+function addDeclarationToModule(options) {
+    return tree => {
+        if (options.skipImport !== undefined && options.skipImport) {
+            return tree;
+        }
+        options.module = new module_finder_1.ModuleFinder(tree).find({
+            name: options.name,
+            path: options.path,
+        });
+        if (!options.module) {
+            return tree;
+        }
+        const content = tree.read(options.module).toString();
+        const declarator = new module_declarator_1.ModuleDeclarator();
+        tree.overwrite(options.module, declarator.declare(content, options));
+        return tree;
+    };
+}

--- a/schematics/commands/module/module.factory.js
+++ b/schematics/commands/module/module.factory.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 exports.main = void 0;
 const core_1 = require('@angular-devkit/core');
 const schematics_1 = require('@angular-devkit/schematics');
-const formatting_1 = require('@nestjs/schematics/dist/utils/formatting');
+const formatting_1 = require('../../utils/formatting');
 const module_declarator_1 = require('../../utils/module.declarator');
 const module_finder_1 = require('@nestjs/schematics/dist/utils/module.finder');
 const name_parser_1 = require('@nestjs/schematics/dist/utils/name.parser');
@@ -29,6 +29,7 @@ function transform(source) {
     const location = new name_parser_1.NameParser().parse(target);
     target.name = (0, formatting_1.normalizeToKebabOrSnakeCase)(location.name);
     target.path = (0, formatting_1.normalizeToKebabOrSnakeCase)(location.path);
+	target.nameFirstLetterToUpper = (0, formatting_1.firstLetterToUpperCase)(target.name);
     target.language = 'ts';
     return target;
 }

--- a/schematics/commands/module/schema.json
+++ b/schematics/commands/module/schema.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "$id": "SchematicsNestModule",
+    "title": "Nest Module Options Schema",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The name of the module.",
+            "$default": {
+                "$source": "argv",
+                "index": 0
+            },
+            "x-prompt": "What name would you like to use for the module?"
+        },
+        "path": {
+            "type": "string",
+            "format": "path",
+            "description": "The path to create the module."
+        },
+        "module": {
+            "type": "string",
+            "format": "path",
+            "description": "The path to import the module."
+        },
+        "language": {
+            "type": "string",
+            "description": "Nest module language (ts/js)."
+        },
+        "sourceRoot": {
+            "type": "string",
+            "description": "Nest module source root directory."
+        },
+        "skipImport": {
+            "type": "boolean",
+            "description": "Flag to skip the module import.",
+            "default": false
+        },
+        "flat": {
+            "type": "boolean",
+            "default": false,
+            "description": "Flag to indicate if a directory is created."
+        }
+    },
+    "required": ["name"]
+}

--- a/schematics/commands/module/template/__name__/__name__.module.ts
+++ b/schematics/commands/module/template/__name__/__name__.module.ts
@@ -1,6 +1,25 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { BaseMongoose } from '../shared/infrastructure/persistence/baseMongoose.repository';
+import { Create<%= classify(name) %> } from './application/use-cases/create<%= nameFirstLetterToUpper %>.usecase';
+import { GetAll<%= classify(name) %>s } from './application/use-cases/getAll<%= nameFirstLetterToUpper %>s.usecase';
+import { <%= classify(name) %>Repository } from './infrastructure/adapters/persistence/<%=name %>.repository';
+import { <%= classify(name) %>CollectionName, <%= classify(name) %>Schema } from './infrastructure/adapters/persistence/<%=name %>.schema';
+import { <%= classify(name) %>Controller } from './infrastructure/adapters/rest/<%=name %>.controller';
 
-@Module({})
+const <%= name.toUpperCase() %>_USE_CASES_PROVIDERS = [Create<%= classify(name) %>, GetAll<%= classify(name) %>s];
+@Module({
+    imports: [
+        MongooseModule.forFeature([
+            {
+                name: <%= classify(name)%>CollectionName,
+                schema: <%= classify(name)%>Schema,
+                discriminators: [{ name: <%= classify(name) %>CollectionName, schema: <%= classify(name)%>Schema }],
+            },
+        ]),
+    ],
+    controllers: [<%= classify(name) %>Controller],
+    providers: [<%= classify(name) %>Repository, BaseMongoose, ...<%= name.toUpperCase() %>_USE_CASES_PROVIDERS],
+    exports: [<%= classify(name) %>Repository, BaseMongoose],
+})
 export class <%= classify(name) %>Module{}

--- a/schematics/commands/module/template/__name__/__name__.module.ts
+++ b/schematics/commands/module/template/__name__/__name__.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { BaseMongoose } from '../shared/infrastructure/persistence/baseMongoose.repository';
+
+@Module({})
+export class <%= classify(name) %>Module{}

--- a/schematics/commands/module/template/__name__/application/dto/create__nameFirstLetterToUpper__Dto.ts
+++ b/schematics/commands/module/template/__name__/application/dto/create__nameFirstLetterToUpper__Dto.ts
@@ -1,0 +1,74 @@
+import { IsArray, IsBoolean, IsDate, IsNotEmpty, IsNumber, IsString, Max, Min } from '@nestjs/class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class Create<%= classify(name) %>Dto {
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    title: string;
+
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    location: string;
+
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    description: string;
+
+    @ApiProperty()
+    @IsNumber()
+    @IsNotEmpty()
+    @Min(0)
+    @Max(5)
+    stars: number;
+
+    @ApiProperty()
+    @Type(() => Date)
+    @IsDate()
+    @IsNotEmpty()
+    startDate: Date;
+
+    @ApiProperty()
+    @Type(() => Date)
+    @IsDate()
+    @IsNotEmpty()
+    endDate: Date;
+
+    @ApiProperty()
+    @IsArray()
+    @IsNotEmpty()
+    projectImages: string[];
+
+    @ApiProperty()
+    @IsNumber()
+    @IsNotEmpty()
+    minimumInvest: number;
+
+    @ApiProperty()
+    @IsNumber()
+    @IsNotEmpty()
+    projectCost: number;
+
+    @ApiProperty()
+    @IsNumber()
+    @IsNotEmpty()
+    totalInvest: number;
+
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    operator: string;
+
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    company: string;
+
+    @ApiProperty()
+    @IsBoolean()
+    @IsNotEmpty()
+    isPublished: boolean;
+}

--- a/schematics/commands/module/template/__name__/application/ports/repository-port.ts
+++ b/schematics/commands/module/template/__name__/application/ports/repository-port.ts
@@ -1,0 +1,9 @@
+import { <%= classify(name) %>Model } from '../../infrastructure/adapters/persistence/<%= name %>.schema';
+import { Create<%= classify(name) %>Dto } from '../dto/create<%= nameFirstLetterToUpper %>Dto';
+
+export interface RepositoryPortCreateInterface {
+    create(<%= name %>: Create<%= classify(name) %>Dto): Promise<<%= classify(name) %>Model>;
+}
+export interface RepositoryPortGetAllInterface {
+    findAll(): Promise<<%= classify(name) %>Model[]>;
+}

--- a/schematics/commands/module/template/__name__/application/ports/rest-adapter-port.ts
+++ b/schematics/commands/module/template/__name__/application/ports/rest-adapter-port.ts
@@ -1,0 +1,10 @@
+import { <%= classify(name) %>Entity } from '../../domain/<%= name %>.entity';
+import { Create<%= classify(name) %>Dto } from '../dto/create<%= nameFirstLetterToUpper %>Dto';
+
+export interface RestAdapterPortCreate<%= classify(name) %>Interface {
+    handler(<%= name %>: Create<%= classify(name) %>Dto): Promise<void>;
+}
+
+export interface RestAdapterPortGetAll<%= classify(name) %>sInterface {
+    handler(): Promise<<%= classify(name) %>Entity[]>;
+}

--- a/schematics/commands/module/template/__name__/application/use-cases/create__nameFirstLetterToUpper__.usecase.ts
+++ b/schematics/commands/module/template/__name__/application/use-cases/create__nameFirstLetterToUpper__.usecase.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { <%= classify(name) %>Repository } from '../../infrastructure/adapters/persistence/<%= name %>.repository';
+import { Create<%= classify(name) %>Dto } from '../dto/create<%= nameFirstLetterToUpper %>Dto';
+import { RepositoryPortCreateInterface } from '../ports/repository-port';
+import { RestAdapterPortCreate<%= classify(name) %>Interface } from '../ports/rest-adapter-port';
+
+@Injectable()
+export class Create<%= classify(name) %> implements RestAdapterPortCreate<%= classify(name) %>Interface {
+    private <%= name %>Repository: RepositoryPortCreateInterface;
+    constructor(<%= name %>Repository: <%= classify(name) %>Repository) {
+        this.<%= name %>Repository = <%= name %>Repository;
+    }
+
+    async handler(<%= name %>: Create<%= classify(name) %>Dto): Promise<void> {
+        try {
+            await this.<%= name %>Repository.create(<%= name %>);
+        } catch (error) {
+            throw new Error(error.message);
+        }
+    }
+}

--- a/schematics/commands/module/template/__name__/application/use-cases/getAll__nameFirstLetterToUpper__s.usecase.ts
+++ b/schematics/commands/module/template/__name__/application/use-cases/getAll__nameFirstLetterToUpper__s.usecase.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { <%= classify(name) %>Entity } from '../../domain/<%= name %>.entity';
+import { <%= classify(name) %>Repository } from '../../infrastructure/adapters/persistence/<%= name %>.repository';
+import { RepositoryPortGetAllInterface } from '../ports/repository-port';
+import { RestAdapterPortGetAll<%= classify(name) %>sInterface } from '../ports/rest-adapter-port';
+
+@Injectable()
+export class GetAll<%= classify(name) %>s implements RestAdapterPortGetAll<%= classify(name) %>sInterface {
+    private <%= name %>Repository: RepositoryPortGetAllInterface;
+    constructor(<%= name %>Repository: <%= classify(name) %>Repository) {
+        this.<%= name %>Repository = <%= name %>Repository;
+    }
+
+    async handler(): Promise<<%= classify(name) %>Entity[]> {
+        try {
+            const <%= name %>sCollection = await this.<%= name %>Repository.findAll();
+            return <%= name %>sCollection.map(<%= name %> => new <%= classify(name) %>Entity(<%= name %>));
+        } catch (error) {
+            throw new Error(error.message);
+        }
+    }
+}

--- a/schematics/commands/module/template/__name__/domain/__name__.entity.ts
+++ b/schematics/commands/module/template/__name__/domain/__name__.entity.ts
@@ -1,0 +1,48 @@
+import { <%= classify(name) %>Interface, <%= classify(name) %>StatusEnum } from './<%= name %>.interface';
+
+export class <%= classify(name) %>Entity implements <%= classify(name) %>Interface {
+    title: string;
+    location: string;
+    description: string;
+    startDate: Date;
+    endDate: Date;
+    operator: string;
+    company: string;
+    projectImages: string[];
+    isPublished: boolean;
+    minimumInvest: number;
+    projectCost: number;
+    totalInvest: number;
+
+    constructor(partial: Partial<<%= classify(name) %>Entity>) {
+        Object.assign(this, partial);
+    }
+
+    get status(): string {
+        return this.get<%= classify(name) %>Status();
+    }
+
+    protected get<%= classify(name) %>Status(): string {
+        try {
+            const currentDate = new Date().getTime();
+            const startDate = new Date(this.startDate.setUTCHours(0, 0, 0, 0)).getTime();
+            const endDate = new Date(this.endDate.setUTCHours(24, 0, 0, 0)).getTime();
+
+            if (startDate > endDate) return <%= classify(name) %>StatusEnum.UNKOWN;
+
+            if (currentDate >= startDate && currentDate <= endDate) {
+                return <%= classify(name) %>StatusEnum.IN_PROGRESS;
+            }
+            if (currentDate < startDate) {
+                return <%= classify(name) %>StatusEnum.UNDER_REVIEW;
+            }
+            if (currentDate > endDate) {
+                return <%= classify(name) %>StatusEnum.IN_PORTFOLIO;
+            }
+
+            return <%= classify(name) %>StatusEnum.UNKOWN;
+        } catch (error) {
+            return <%= classify(name) %>StatusEnum.UNKOWN;
+        }
+    }
+}

--- a/schematics/commands/module/template/__name__/domain/__name__.interface.ts
+++ b/schematics/commands/module/template/__name__/domain/__name__.interface.ts
@@ -1,0 +1,21 @@
+export interface <%= classify(name) %>Interface {
+    title: string;
+    location: string;
+    description: string;
+    startDate: Date;
+    endDate: Date;
+    minimumInvest: number;
+    projectCost: number;
+    totalInvest: number;
+    operator: string;
+    company: string;
+    projectImages: string[];
+    isPublished: boolean;
+}
+
+export enum <%= classify(name) %>StatusEnum {
+    IN_PROGRESS = 'in_progress',
+    UNDER_REVIEW = 'under_review',
+    IN_PORTFOLIO = 'in_portfolio',
+    UNKOWN = 'unkown',
+}

--- a/schematics/commands/module/template/__name__/domain/__name__.test.ts
+++ b/schematics/commands/module/template/__name__/domain/__name__.test.ts
@@ -1,0 +1,65 @@
+import { <%= classify(name) %>Entity } from './<%= name %>.entity';
+import { <%= classify(name) %>Interface, <%= classify(name) %>StatusEnum } from './<%= name %>.interface';
+
+const MOCK_PROJECT: <%= classify(name) %>Interface = {
+    title: 'test',
+    location: 'test',
+    description: 'test',
+    totalInvest: 1,
+    operator: 'test',
+    company: 'test',
+    projectImages: ['test'],
+    startDate: new Date('2021-01-01'),
+    endDate: new Date('2024-01-01'),
+    minimumInvest: 1,
+    projectCost: 1,
+    isPublished: false,
+};
+
+let testData = { ...MOCK_PROJECT };
+
+afterEach(() => {
+    testData = { ...MOCK_PROJECT };
+});
+
+describe.only('Project entity test', () => {
+    it('project status must be "unknown" when invalid dates are provided', () => {
+        testData.startDate = new Date('2024-01-01');
+        testData.endDate = new Date('2021-01-01');
+        const project = new <%= classify(name) %>Entity(testData);
+        expect(project.status).toBe(<%= classify(name) %>StatusEnum.UNKOWN);
+
+        testData.startDate = null;
+        const project2 = new <%= classify(name) %>Entity(testData);
+        expect(project2.status).toBe(<%= classify(name) %>StatusEnum.UNKOWN);
+
+        testData.endDate = null;
+        const project3 = new <%= classify(name) %>Entity(testData);
+        expect(project3.status).toBe(<%= classify(name) %>StatusEnum.UNKOWN);
+    });
+
+    it('project status must be "in_progress" if current date is between start and end dates', () => {
+        const dateAtPreviousMonth = new Date(new Date().setMonth(new Date().getMonth() - 1));
+        const dateAtNextMonth = new Date(new Date().setMonth(new Date().getMonth() + 1));
+        testData.startDate = dateAtPreviousMonth;
+        testData.endDate = dateAtNextMonth;
+
+        const project = new <%= classify(name) %>Entity(testData);
+        expect(project.status).toBe(<%= classify(name) %>StatusEnum.IN_PROGRESS);
+    });
+    it('project status must be "under_review" if current date is before start date', () => {
+        const dateAtNextMonth = new Date(new Date().setMonth(new Date().getMonth() + 1));
+        testData.startDate = dateAtNextMonth;
+
+        const project = new <%= classify(name) %>Entity(testData);
+        expect(project.status).toBe(<%= classify(name) %>StatusEnum.UNDER_REVIEW);
+    });
+
+    it('project status must be "in_portfolio" if current date is after end date', () => {
+        const dateAtPreviousMonth = new Date(new Date().setMonth(new Date().getMonth() - 1));
+        testData.endDate = dateAtPreviousMonth;
+
+        const project = new <%= classify(name) %>Entity(testData);
+        expect(project.status).toBe(<%= classify(name) %>StatusEnum.IN_PORTFOLIO);
+    });
+});

--- a/schematics/commands/module/template/__name__/infrastructure/adapters/persistence/__name__.repository.ts
+++ b/schematics/commands/module/template/__name__/infrastructure/adapters/persistence/__name__.repository.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { RepositoryPortCreateInterface } from 'src/modules/<%= name %>/application/ports/repository-port';
+import { BaseMongoose } from '../../../../shared/infrastructure/persistence/baseMongoose.repository';
+import { <%= classify(name) %>CollectionName, <%= classify(name) %>Model } from './<%= name %>.schema';
+
+@Injectable()
+export class <%= classify(name) %>Repository
+    extends BaseMongoose<<%= classify(name) %>Model>
+    implements RepositoryPortCreateInterface, RepositoryPortCreateInterface
+{
+    constructor(@InjectModel(<%= classify(name) %>CollectionName) private <%= name %>Model: Model<<%= classify(name) %>Model>) {
+        super();
+        this.model = this.<%= name %>Model;
+    }
+}

--- a/schematics/commands/module/template/__name__/infrastructure/adapters/persistence/__name__.schema.ts
+++ b/schematics/commands/module/template/__name__/infrastructure/adapters/persistence/__name__.schema.ts
@@ -1,0 +1,84 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import * as mongoose from 'mongoose';
+import { Document } from 'mongoose';
+import { <%= classify(name) %>Interface } from '../../../domain/<%= name %>.interface';
+
+@Schema({ timestamps: true })
+export class <%= classify(name) %>Model implements <%= classify(name) %>Interface {
+    @Prop({
+        required: true,
+        maxlength: 20,
+    })
+    title: string;
+
+    @Prop({
+        required: true,
+        maxlength: 500,
+    })
+    description: string;
+
+    @Prop({
+        required: true,
+        type: mongoose.Schema.Types.Date,
+    })
+    startDate;
+
+    @Prop({
+        required: true,
+        type: mongoose.Schema.Types.Date,
+    })
+    endDate;
+
+    @Prop({
+        required: true,
+        maxlength: 20,
+    })
+    location: string;
+
+    @Prop({
+        required: true,
+        type: mongoose.Schema.Types.Decimal128,
+    })
+    minimumInvest;
+
+    @Prop({
+        required: true,
+        type: mongoose.Schema.Types.Decimal128,
+    })
+    projectCost;
+
+    @Prop({
+        required: true,
+        type: mongoose.Schema.Types.Decimal128,
+    })
+    totalInvest;
+
+    @Prop({
+        required: true,
+        maxlength: 20,
+    })
+    operator: string;
+
+    @Prop({
+        required: true,
+        maxlength: 20,
+    })
+    company: string;
+
+    @Prop({
+        required: true,
+        maxlength: 5,
+        type: [String],
+    })
+    projectImages: string[];
+
+    @Prop({
+        required: true,
+        type: Boolean,
+    })
+    isPublished: boolean;
+}
+
+export type <%= classify(name) %>Document = <%= classify(name) %>Model & Document;
+export const <%= classify(name) %>Schema = SchemaFactory.createForClass(<%= classify(name) %>Model);
+export const <%= classify(name) %>CollectionName = '<%= classify(name) %>';

--- a/schematics/commands/module/template/__name__/infrastructure/adapters/rest/__name__.controller.ts
+++ b/schematics/commands/module/template/__name__/infrastructure/adapters/rest/__name__.controller.ts
@@ -1,0 +1,57 @@
+import {
+    Body,
+    ClassSerializerInterceptor,
+    Controller,
+    Get,
+    Post,
+    SerializeOptions,
+    UseInterceptors,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ClassTransformOptions } from 'class-transformer';
+import { SentryInterceptor } from 'src/lib/errors/sentry.interceptor';
+import { Create<%= classify(name) %>Dto } from 'src/modules/<%= name %>/application/dto/create<%= nameFirstLetterToUpper %>Dto';
+import {
+    RestAdapterPortCreate<%= classify(name) %>Interface,
+    RestAdapterPortGetAll<%= classify(name) %>sInterface,
+} from 'src/modules/<%= name %>/application/ports/rest-adapter-port';
+import { Create<%= classify(name) %> } from 'src/modules/<%= name %>/application/use-cases/create<%= nameFirstLetterToUpper %>.usecase';
+import { GetAll<%= classify(name) %>s } from 'src/modules/<%= name %>/application/use-cases/getAll<%= nameFirstLetterToUpper %>s.usecase';
+import { <%= classify(name) %>ResponseDto } from '../../dto/<%= nameFirstLetterToUpper %>ResponseDto';
+
+const DEFAULT_SERIALIZER_OPTIONS: ClassTransformOptions = {
+    strategy: 'excludeAll',
+};
+
+@ApiTags('<%= name %>')
+@UseInterceptors(SentryInterceptor)
+@Controller('<%= name %>')
+@UseInterceptors(ClassSerializerInterceptor)
+@SerializeOptions(DEFAULT_SERIALIZER_OPTIONS)
+export class <%= classify(name) %>Controller {
+    private create<%= classify(name) %>UseCase: RestAdapterPortCreate<%= classify(name) %>Interface;
+    private getAll<%= classify(name) %>sUseCase: RestAdapterPortGetAll<%= classify(name) %>sInterface;
+
+    constructor(create<%= classify(name) %>UseCase: Create<%= classify(name) %>, getAll<%= classify(name) %>sUseCase: GetAll<%= classify(name) %>s) {
+        this.create<%= classify(name) %>UseCase = create<%= classify(name) %>UseCase;
+        this.getAll<%= classify(name) %>sUseCase = getAll<%= classify(name) %>sUseCase;
+    }
+
+    @Get()
+    async getAll<%= classify(name) %>s(): Promise<<%= classify(name) %>ResponseDto[]> {
+        try {
+            const <%= name %>sCollection = await this.getAll<%= classify(name) %>sUseCase.handler();
+            return <%= name %>sCollection.map(<%= name %> => new <%= classify(name) %>ResponseDto(<%= name %>));
+        } catch (error) {
+            throw new Error(error.message);
+        }
+    }
+    @Post()
+    async create<%= classify(name) %>(@Body() create<%= classify(name) %>Dto: Create<%= classify(name) %>Dto): Promise<void> {
+        try {
+            await this.create<%= classify(name) %>UseCase.handler(create<%= classify(name) %>Dto);
+        } catch (error) {
+            throw new Error(error.message);
+        }
+    }
+}

--- a/schematics/commands/module/template/__name__/infrastructure/dto/__nameFirstLetterToUpper__ResponseDto.ts
+++ b/schematics/commands/module/template/__name__/infrastructure/dto/__nameFirstLetterToUpper__ResponseDto.ts
@@ -1,0 +1,42 @@
+import { Expose, Transform } from 'class-transformer';
+import { ObjectId } from 'mongoose';
+import { <%= classify(name) %>Entity } from '../../domain/<%= name %>.entity';
+
+export class <%= classify(name) %>ResponseDto extends <%= classify(name) %>Entity {
+    private _id: ObjectId;
+    @Expose()
+    get id(): string {
+        return this._id.toString();
+    }
+    @Expose()
+    title: string;
+    @Expose()
+    stars: number;
+    @Expose()
+    location: string;
+    @Expose()
+    rooms: number;
+    @Expose()
+    description: string;
+    @Expose()
+    startDate: Date;
+    @Expose()
+    endDate: Date;
+    @Expose()
+    operator: string;
+    @Expose()
+    company: string;
+    @Expose()
+    projectImages: string[];
+    @Expose()
+    isPublished: boolean;
+    @Expose()
+    @Transform(({ value }) => Number(value.toString()))
+    minimumInvest: number;
+    @Expose()
+    @Transform(({ value }) => Number(value.toString()))
+    projectCost: number;
+    @Expose()
+    @Transform(({ value }) => Number(value.toString()))
+    totalInvest: number;
+}

--- a/schematics/utils/formatting.d.ts
+++ b/schematics/utils/formatting.d.ts
@@ -1,0 +1,2 @@
+export declare function normalizeToKebabOrSnakeCase(str: string): string;
+export declare function firstLetterToUpperCase(str: string): string;

--- a/schematics/utils/formatting.js
+++ b/schematics/utils/formatting.js
@@ -1,0 +1,20 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.normalizeToKebabOrSnakeCase = void 0;
+exports.firstLetterToUpperCase = void 0;
+
+function normalizeToKebabOrSnakeCase(str) {
+    const STRING_DASHERIZE_REGEXP = /\s/g;
+    const STRING_DECAMELIZE_REGEXP = /([a-z\d])([A-Z])/g;
+    return str
+        .replace(STRING_DECAMELIZE_REGEXP, '$1-$2')
+        .toLowerCase()
+        .replace(STRING_DASHERIZE_REGEXP, '-');
+}
+
+function firstLetterToUpperCase(str) {
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+exports.normalizeToKebabOrSnakeCase = normalizeToKebabOrSnakeCase;
+exports.firstLetterToUpperCase = firstLetterToUpperCase;

--- a/schematics/utils/module-import.declarator.d.ts
+++ b/schematics/utils/module-import.declarator.d.ts
@@ -1,0 +1,10 @@
+import { DeclarationOptions } from './module.declarator';
+import { PathSolver } from '@nestjs/schematics/dist/utils/path.solver';
+export declare class ModuleImportDeclarator {
+    private solver;
+    constructor(solver?: PathSolver);
+    declare(content: string, options: DeclarationOptions): string;
+    private findImportsEndpoint;
+    private buildLineToInsert;
+    private computeRelativePath;
+}

--- a/schematics/utils/module-import.declarator.js
+++ b/schematics/utils/module-import.declarator.js
@@ -1,0 +1,39 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ModuleImportDeclarator = void 0;
+const core_1 = require("@angular-devkit/core");
+const path_solver_1 = require("@nestjs/schematics/dist/utils/path.solver");
+class ModuleImportDeclarator {
+    constructor(solver = new path_solver_1.PathSolver()) {
+        this.solver = solver;
+    }
+    declare(content, options) {
+        const toInsert = this.buildLineToInsert(options);
+        const contentLines = content.split('\n');
+        const finalImportIndex = this.findImportsEndpoint(contentLines);
+        contentLines.splice(finalImportIndex + 1, 0, toInsert);
+        return contentLines.join('\n');
+    }
+    findImportsEndpoint(contentLines) {
+        const reversedContent = Array.from(contentLines).reverse();
+        const reverseImports = reversedContent.filter(line => line.match(/\} from ('|")/));
+        if (reverseImports.length <= 0) {
+            return 0;
+        }
+        return contentLines.indexOf(reverseImports[0]);
+    }
+    buildLineToInsert(options) {
+        return `import { ${options.symbol} } from '${this.computeRelativePath(options)}';`;
+    }
+    computeRelativePath(options) {
+        let importModulePath;
+        if (options.type !== undefined) {
+            importModulePath = (0, core_1.normalize)(`/${options.path}/${options.name}/${options.name}.${options.type}`);
+        }
+        else {
+            importModulePath = (0, core_1.normalize)(`/${options.path}/${options.name}`);
+        }
+        return this.solver.relative(options.module, importModulePath);
+    }
+}
+exports.ModuleImportDeclarator = ModuleImportDeclarator;

--- a/schematics/utils/module.declarator.d.ts
+++ b/schematics/utils/module.declarator.d.ts
@@ -1,0 +1,23 @@
+import { Path } from '@angular-devkit/core';
+import { ModuleImportDeclarator } from './module-import.declarator';
+import { ModuleMetadataDeclarator } from '@nestjs/schematics/dist/utils/module-metadata.declarator';
+export interface DeclarationOptions {
+    metadata: string;
+    type?: string;
+    name: string;
+    className?: string;
+    path: Path;
+    module: Path;
+    symbol?: string;
+    staticOptions?: {
+        name: string;
+        value: Record<string, any>;
+    };
+}
+export declare class ModuleDeclarator {
+    private imports;
+    private metadata;
+    constructor(imports?: ModuleImportDeclarator, metadata?: ModuleMetadataDeclarator);
+    declare(content: string, options: DeclarationOptions): string;
+    private computeSymbol;
+}

--- a/schematics/utils/module.declarator.js
+++ b/schematics/utils/module.declarator.js
@@ -1,0 +1,32 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ModuleDeclarator = void 0;
+const strings_1 = require("@angular-devkit/core/src/utils/strings");
+const module_import_declarator_1 = require("./module-import.declarator");
+const module_metadata_declarator_1 = require("@nestjs/schematics/dist/utils/module-metadata.declarator");
+class ModuleDeclarator {
+    constructor(imports = new module_import_declarator_1.ModuleImportDeclarator(), metadata = new module_metadata_declarator_1.ModuleMetadataDeclarator()) {
+        this.imports = imports;
+        this.metadata = metadata;
+    }
+    declare(content, options) {
+        options = this.computeSymbol(options);
+        content = this.imports.declare(content, options);
+        content = this.metadata.declare(content, options);
+        return content;
+    }
+    computeSymbol(options) {
+        const target = Object.assign({}, options);
+        if (options.className) {
+            target.symbol = options.className;
+        }
+        else if (options.type !== undefined) {
+            target.symbol = (0, strings_1.classify)(options.name).concat((0, strings_1.capitalize)(options.type));
+        }
+        else {
+            target.symbol = (0, strings_1.classify)(options.name);
+        }
+        return target;
+    }
+}
+exports.ModuleDeclarator = ModuleDeclarator;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "dist", "test", "**/*spec.ts", "schematics"]
 }


### PR DESCRIPTION
## **Ticket**

## **Problem**

A la hora de generar un módulo, el comando por defecto crea una estructura muy básica

## **Changelog**

Se ha modificado el schematic por defecto de Netsjs. Ahora cuando se ejecuta `nest generate module`  se nos crea una carpeta con el nombre del módulo, con las subcarpetas domain, application, infrastructure y todos los archivos necesarios

## **How to test**

Para probar la funcionalidad podemos seguir los siguientes pasos:

1. Ejecutamos el comando `nest generate module` con el nombre del modulo que queremos crear
2. En la carpeta `src/modules/` debería generarse un módulo con la con las subcarpetas domain, application, infrastructure y actualizarse el archivo 'src/app.module.ts` con el nuevo módulo 

## **Type of change (Optional)**

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Refactor (non-breaking change which modifies code keeping the same functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
